### PR TITLE
Initial Spectral ruleset

### DIFF
--- a/spectral/.spectral.yml
+++ b/spectral/.spectral.yml
@@ -1,0 +1,7 @@
+extends:
+  - ./rules/schema-at-root.spectral.yml
+  - ./rules/schema-resource-root.spectral.yml
+  - ./rules/id-at-root.spectral.yml
+  - ./rules/incompatible-type-validations.spectral.yml
+  - ./rules/if-then-else.spectral.yml
+  - ./rules/unknown-format.spectral.yml

--- a/spectral/README.md
+++ b/spectral/README.md
@@ -1,0 +1,26 @@
+[Spectral](https://stoplight.io/open-source/spectral) is a linting tool for JSON and YAML.
+
+It's most used to help developers make informed decisions when composing OpenAPI and AsyncAPI documents.
+
+This folder supplies a ruleset that can do the same for JSON Schema in general.
+
+Spectral works by defining a set of rules.  The rules defining herein work independently of each other and typically focus on a single problem or area.
+
+For more information on how Spectral rules work, you can read their [full documentation](https://docs.stoplight.io/docs/spectral/).
+
+## Using the ruleset
+
+Currently the rules are only published as part of this repository, however we are exploring other publication options.
+
+To use these rules, first clone this repository.
+
+You can run the CLI linter (downloadable separately) from this folder (_./spectral_).  Check the CLI documentation for more options and configuration.
+
+### In Visual Studio Code
+
+If you're a VSCode user, Spectral offers an extension.  There are a couple gotchas with using it, though.
+
+- It expects the .spectral.yml file to be at the root of the workspace, so you may need to copy these files into the root folder of wherever your JSON/YAML files are and open _that folder_ (not a parent) in VSCode.
+- You'll need to configure the extension to ignore **/*.spectral.yml files so that it doesn't try to validate the rule files themselves.
+
+Once that's set up, you'll get problems reported in the Problems pane.

--- a/spectral/rules/const-independence.spectral.yml
+++ b/spectral/rules/const-independence.spectral.yml
@@ -1,0 +1,67 @@
+rules:
+  const-should-stand-alone:
+    description: Schemas with const should not have additional validation
+    severity: error
+    given: $..[?(@.const)]
+    then:
+      - function: undefined
+        field: type
+      - function: undefined
+        field: minimum
+      - function: undefined
+        field: maximum
+      - function: undefined
+        field: exclusiveMinimum
+      - function: undefined
+        field: exclusiveMaximum
+      - function: undefined
+        field: multipleOf
+      - function: undefined
+        field: minLength
+      - function: undefined
+        field: maxLength
+      - function: undefined
+        field: pattern
+      - function: undefined
+        field: minItems
+      - function: undefined
+        field: maxItems
+      - function: undefined
+        field: items
+      - function: undefined
+        field: uniqueItems
+      - function: undefined
+        field: additionalItems
+      - function: undefined
+        field: unevaluatedItems
+      - function: undefined
+        field: contains
+      - function: undefined
+        field: minContains
+      - function: undefined
+        field: maxContains
+      - function: undefined
+        field: properties
+      - function: undefined
+        field: additionalProperties
+      - function: undefined
+        field: unevaluatedProperties
+      - function: undefined
+        field: propertyNames
+      - function: undefined
+        field: patternProperties
+      - function: undefined
+        field: minProperties
+      - function: undefined
+        field: maxProperties
+      - function: undefined
+        field: required
+      - function: undefined
+        field: dependentRequired
+      - function: undefined
+        field: dependentSchema
+      - function: undefined
+        field: dependencies
+      - function: undefined
+        field: enum
+

--- a/spectral/rules/enum-independence.spectral.yml
+++ b/spectral/rules/enum-independence.spectral.yml
@@ -1,0 +1,66 @@
+rules:
+  enum-should-stand-alone:
+    description: Schemas with enum should not have additional validation
+    severity: error
+    given: $..[?(@.enum)]
+    then:
+      - function: undefined
+        field: type
+      - function: undefined
+        field: minimum
+      - function: undefined
+        field: maximum
+      - function: undefined
+        field: exclusiveMinimum
+      - function: undefined
+        field: exclusiveMaximum
+      - function: undefined
+        field: multipleOf
+      - function: undefined
+        field: minLength
+      - function: undefined
+        field: maxLength
+      - function: undefined
+        field: pattern
+      - function: undefined
+        field: minItems
+      - function: undefined
+        field: maxItems
+      - function: undefined
+        field: items
+      - function: undefined
+        field: uniqueItems
+      - function: undefined
+        field: additionalItems
+      - function: undefined
+        field: unevaluatedItems
+      - function: undefined
+        field: contains
+      - function: undefined
+        field: minContains
+      - function: undefined
+        field: maxContains
+      - function: undefined
+        field: properties
+      - function: undefined
+        field: additionalProperties
+      - function: undefined
+        field: unevaluatedProperties
+      - function: undefined
+        field: propertyNames
+      - function: undefined
+        field: patternProperties
+      - function: undefined
+        field: minProperties
+      - function: undefined
+        field: maxProperties
+      - function: undefined
+        field: required
+      - function: undefined
+        field: dependentRequired
+      - function: undefined
+        field: dependentSchema
+      - function: undefined
+        field: dependencies
+      - function: undefined
+        field: const

--- a/spectral/rules/id-at-root.spectral.yml
+++ b/spectral/rules/id-at-root.spectral.yml
@@ -1,0 +1,8 @@
+rules:
+  require-id-root:
+    description: Root must include $id.
+    severity: error
+    given: $
+    then:
+      function: truthy
+      field: $id

--- a/spectral/rules/if-then-else.spectral.yml
+++ b/spectral/rules/if-then-else.spectral.yml
@@ -1,0 +1,41 @@
+rules:
+  if-requires-then-or-else:
+    description: 'The `if` keyword will be ignored unless an adjacent `then` and/or `else` keyword is present.'
+    severity: error
+    given:
+      - $
+      - $..[?(@.if)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              not:
+                anyOf:
+                  - required: 
+                    - then
+                  - required:
+                    - else
+            then:
+              properties:
+                if: false
+  then-and-else-require-if:
+    description: 'The `then` and `else` keywords will be ignored unless an adjacent `if` keyword is present.'
+    severity: error
+    given:
+      - $
+      - $..[?(@.then)]
+      - $..[?(@.else)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              not:
+                required:
+                  - if
+            then:
+              properties:
+                then: false
+                else: false
+                

--- a/spectral/rules/incompatible-type-additionalItems.spectral.yml
+++ b/spectral/rules/incompatible-type-additionalItems.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  additionalItems-only-applies-to-objects:
+    description: The additionalItems keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.additionalItems!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                additionalItems: false

--- a/spectral/rules/incompatible-type-additionalProperties.spectral.yml
+++ b/spectral/rules/incompatible-type-additionalProperties.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  additionalProperties-only-applies-to-objects:
+    description: The additionalProperties keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.additionalProperties!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - array
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                additionalProperties: false

--- a/spectral/rules/incompatible-type-contains.spectral.yml
+++ b/spectral/rules/incompatible-type-contains.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  contains-only-applies-to-objects:
+    description: The contains keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.contains!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                contains: false

--- a/spectral/rules/incompatible-type-dependencies.spectral.yml
+++ b/spectral/rules/incompatible-type-dependencies.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  dependencies-only-applies-to-objects:
+    description: The dependencies keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.dependencies!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - array
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                dependencies: false

--- a/spectral/rules/incompatible-type-dependentRequired.spectral.yml
+++ b/spectral/rules/incompatible-type-dependentRequired.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  dependentRequired-only-applies-to-objects:
+    description: The dependentRequired keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.dependentRequired!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - array
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                dependentRequired: false

--- a/spectral/rules/incompatible-type-dependentSchema.spectral.yml
+++ b/spectral/rules/incompatible-type-dependentSchema.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  dependentSchema-only-applies-to-objects:
+    description: The dependentSchema keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.dependentSchema!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - array
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                dependentSchema: false

--- a/spectral/rules/incompatible-type-exclusiveMaximum.spectral.yml
+++ b/spectral/rules/incompatible-type-exclusiveMaximum.spectral.yml
@@ -1,0 +1,25 @@
+rules:
+  exclusiveMaximum-only-applies-to-numbers:
+    description: The exclusiveMaximum keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.exclusiveMaximum!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - array
+                    - string
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                exclusiveMaximum: false

--- a/spectral/rules/incompatible-type-exclusiveMinimum.spectral.yml
+++ b/spectral/rules/incompatible-type-exclusiveMinimum.spectral.yml
@@ -1,0 +1,25 @@
+rules:
+  exclusiveMinimum-only-applies-to-numbers:
+    description: The exclusiveMinimum keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.exclusiveMinimum!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - array
+                    - string
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                exclusiveMinimum: false

--- a/spectral/rules/incompatible-type-items.spectral.yml
+++ b/spectral/rules/incompatible-type-items.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  items-only-applies-to-objects:
+    description: The items keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.items!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                items: false

--- a/spectral/rules/incompatible-type-maxContains.spectral.yml
+++ b/spectral/rules/incompatible-type-maxContains.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  maxContains-only-applies-to-objects:
+    description: The maxContains keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.maxContains!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                maxContains: false

--- a/spectral/rules/incompatible-type-maxItems.spectral.yml
+++ b/spectral/rules/incompatible-type-maxItems.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  maxItems-only-applies-to-objects:
+    description: The maxItems keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.maxItems!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                maxItems: false

--- a/spectral/rules/incompatible-type-maxLength.spectral.yml
+++ b/spectral/rules/incompatible-type-maxLength.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  maxLength-only-applies-to-strings:
+    description: The maxLength keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.maxLength!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - array
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                maxLength: false

--- a/spectral/rules/incompatible-type-maxProperties.spectral.yml
+++ b/spectral/rules/incompatible-type-maxProperties.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  maxProperties-only-applies-to-objects:
+    description: The maxProperties keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.maxProperties!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - array
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                maxProperties: false

--- a/spectral/rules/incompatible-type-maximum.spectral.yml
+++ b/spectral/rules/incompatible-type-maximum.spectral.yml
@@ -1,0 +1,25 @@
+rules:
+  maximum-only-applies-to-numbers:
+    description: The maximum keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.maximum!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - array
+                    - string
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                maximum: false

--- a/spectral/rules/incompatible-type-minContains.spectral.yml
+++ b/spectral/rules/incompatible-type-minContains.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  minContains-only-applies-to-objects:
+    description: The minContains keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.minContains!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                minContains: false

--- a/spectral/rules/incompatible-type-minItems.spectral.yml
+++ b/spectral/rules/incompatible-type-minItems.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  minItems-only-applies-to-objects:
+    description: The minItems keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.minItems!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                minItems: false

--- a/spectral/rules/incompatible-type-minLength.spectral.yml
+++ b/spectral/rules/incompatible-type-minLength.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  minLength-only-applies-to-strings:
+    description: The minLength keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.minLength!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - array
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                minLength: false

--- a/spectral/rules/incompatible-type-minProperties.spectral.yml
+++ b/spectral/rules/incompatible-type-minProperties.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  minProperties-only-applies-to-objects:
+    description: The minProperties keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.minProperties!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - array
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                minProperties: false

--- a/spectral/rules/incompatible-type-minimum.spectral.yml
+++ b/spectral/rules/incompatible-type-minimum.spectral.yml
@@ -1,0 +1,25 @@
+rules:
+  minimum-only-applies-to-numbers:
+    description: The minimum keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.minimum!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - array
+                    - string
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                minimum: false

--- a/spectral/rules/incompatible-type-multipleOf.spectral.yml
+++ b/spectral/rules/incompatible-type-multipleOf.spectral.yml
@@ -1,0 +1,25 @@
+rules:
+  multipleOf-only-applies-to-numbers:
+    description: The multipleOf keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.multipleOf!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - array
+                    - string
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                multipleOf: false

--- a/spectral/rules/incompatible-type-pattern.spectral.yml
+++ b/spectral/rules/incompatible-type-pattern.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  pattern-only-applies-to-strings:
+    description: The pattern keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.pattern!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - array
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                pattern: false

--- a/spectral/rules/incompatible-type-patternProperties.spectral.yml
+++ b/spectral/rules/incompatible-type-patternProperties.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  patternProperties-only-applies-to-objects:
+    description: The patternProperties keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.patternProperties!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - array
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                patternProperties: false

--- a/spectral/rules/incompatible-type-prefixItems.spectral.yml
+++ b/spectral/rules/incompatible-type-prefixItems.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  prefixItems-only-applies-to-objects:
+    description: The prefixItems keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.prefixItems!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                prefixItems: false

--- a/spectral/rules/incompatible-type-properties.spectral.yml
+++ b/spectral/rules/incompatible-type-properties.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  properties-only-applies-to-objects:
+    description: The properties keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.properties!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - array
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                properties: false

--- a/spectral/rules/incompatible-type-propertyNames.spectral.yml
+++ b/spectral/rules/incompatible-type-propertyNames.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  propertyNames-only-applies-to-objects:
+    description: The propertyNames keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.propertyNames!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - array
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                propertyNames: false

--- a/spectral/rules/incompatible-type-required.spectral.yml
+++ b/spectral/rules/incompatible-type-required.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  required-only-applies-to-objects:
+    description: The required keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.required!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - array
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                required: false

--- a/spectral/rules/incompatible-type-unevaluatedItems.spectral.yml
+++ b/spectral/rules/incompatible-type-unevaluatedItems.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  unevaluatedItems-only-applies-to-objects:
+    description: The unevaluatedItems keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.unevaluatedItems!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                unevaluatedItems: false

--- a/spectral/rules/incompatible-type-unevaluatedProperties.spectral.yml
+++ b/spectral/rules/incompatible-type-unevaluatedProperties.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  unevaluatedProperties-only-applies-to-objects:
+    description: The unevaluatedProperties keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.unevaluatedProperties!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - array
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                unevaluatedProperties: false

--- a/spectral/rules/incompatible-type-uniqueItems.spectral.yml
+++ b/spectral/rules/incompatible-type-uniqueItems.spectral.yml
@@ -1,0 +1,26 @@
+rules:
+  uniqueItems-only-applies-to-objects:
+    description: The uniqueItems keyword is incompatible with the specified type.
+    severity: error
+    given:
+      - $
+      - $..[?(@.uniqueItems!=null)]
+    then:
+      - function: schema
+        functionOptions:
+          schema:
+            if:
+              properties:
+                type:
+                  enum:
+                    - object
+                    - string
+                    - number
+                    - integer
+                    - boolean
+                    - 'null'
+              required:
+                - type
+            then:
+              properties:
+                uniqueItems: false

--- a/spectral/rules/incompatible-type-validations.spectral.yml
+++ b/spectral/rules/incompatible-type-validations.spectral.yml
@@ -1,0 +1,32 @@
+extends:
+  - ./enum-independence.spectral.yml
+  - ./const-independence.spectral.yml
+  - ./incompatible-type-minimum.spectral.yml
+  - ./incompatible-type-maximum.spectral.yml
+  - ./incompatible-type-exclusiveMaximum.spectral.yml
+  - ./incompatible-type-exclusiveMinimum.spectral.yml
+  - ./incompatible-type-multipleOf.spectral.yml
+  - ./incompatible-type-minLength.spectral.yml
+  - ./incompatible-type-maxLength.spectral.yml
+  - ./incompatible-type-properties.spectral.yml
+  - ./incompatible-type-propertyNames.spectral.yml
+  - ./incompatible-type-patternProperties.spectral.yml
+  - ./incompatible-type-additionalProperties.spectral.yml
+  - ./incompatible-type-unevaluatedProperties.spectral.yml
+  - ./incompatible-type-minProperties.spectral.yml
+  - ./incompatible-type-maxProperties.spectral.yml
+  - ./incompatible-type-required.spectral.yml
+  - ./incompatible-type-dependentRequired.spectral.yml
+  - ./incompatible-type-dependentSchema.spectral.yml
+  - ./incompatible-type-dependencies.spectral.yml
+  - ./incompatible-type-items.spectral.yml
+  - ./incompatible-type-minItems.spectral.yml
+  - ./incompatible-type-maxItems.spectral.yml
+  - ./incompatible-type-uniqueItems.spectral.yml
+  - ./incompatible-type-additionalItems.spectral.yml
+  - ./incompatible-type-unevaluatedItems.spectral.yml
+  - ./incompatible-type-contains.spectral.yml
+  - ./incompatible-type-minContains.spectral.yml
+  - ./incompatible-type-maxContains.spectral.yml
+
+

--- a/spectral/rules/schema-at-root.spectral.yml
+++ b/spectral/rules/schema-at-root.spectral.yml
@@ -1,0 +1,8 @@
+rules:
+  require-schema-root:
+    description: Root must include $schema.
+    severity: error
+    given: $
+    then:
+      function: truthy
+      field: $schema

--- a/spectral/rules/schema-resource-root.spectral.yml
+++ b/spectral/rules/schema-resource-root.spectral.yml
@@ -1,0 +1,8 @@
+rules:
+  disallow-schema-unless-resource-root:
+    description: $schema is not allowed unless $id is present.
+    severity: error
+    given: $..[?(!@['$id'] && @['$schema'])]
+    then:
+      function: undefined
+      field: $schema

--- a/spectral/rules/unknown-format.spectral.yml
+++ b/spectral/rules/unknown-format.spectral.yml
@@ -1,0 +1,31 @@
+rules:
+  unknown-formats:
+    description: '`format` values not defined in the specification may not be recognized'
+    severity: warn
+    given:
+      - $
+      - $..*
+    then:
+      function: enumeration
+      field: format
+      functionOptions:
+        values:
+          - date
+          - date-time
+          - duration
+          - email
+          - hostname
+          - idn-email
+          - idn-hostname
+          - ipv4
+          - ipv6
+          - iri
+          - iri-reference
+          - json-pointer
+          - regex
+          - relative-json-pointer
+          - time
+          - uri
+          - uri-reference
+          - uri-template
+          - uuid

--- a/spectral/rules/unknown-format.spectral.yml
+++ b/spectral/rules/unknown-format.spectral.yml
@@ -4,7 +4,7 @@ rules:
     severity: warn
     given:
       - $
-      - $..*
+      - $..[?(@.format)]
     then:
       function: enumeration
       field: format


### PR DESCRIPTION
(from https://github.com/orgs/json-schema-org/discussions/323)

This is a ruleset for Spectral that covers

- #1
- #2
- #3
- #5
- #16
- #17

I've been using the Spectral VSCode extension to write them.  There are a couple gotchas when using it, though:

- It expects the `.spectral.yml` file to be at the root of the workspace, so you'll need to open the _/spectral_ folder instead of the repo root.
- You'll need to configure the extension to ignore _**/*.spectral.yml_ files so that it doesn't try to validate the rule files themselves.

The approach I'm using in designing these rules is to get VSCode to highlight the problem keyword specifically.  For example, highlighting `if` (or its value) if there isn't also a `then` or `else`.  This provides a better dev experience by showing where the problem is rather than just telling them.

For many of these rules I found simpler ways to express the rule, but those ways seemed to highlight more of the JSON than was necessary (e.g. highlighting the entire subschema that contains the `if` doesn't tell you that the `if` is the problem).

We will be looking for a way to properly publish these, but for now this gets them off of my local computer.

I'll also include a readme in the spectral folder.